### PR TITLE
Adjust chocoInstall/Uninstall variable declarations to be compatible with chocolatey internalizer

### DIFF
--- a/tools/chocolateyInstall.ps1.in
+++ b/tools/chocolateyInstall.ps1.in
@@ -8,9 +8,9 @@ Version: 1.0.0
 #>
 $ErrorActionPreference = 'Stop'
 
-New-Variable -Name package -Value 'erlang' -Option Constant
-New-Variable -Name otp_version -Value '@@OTP_VERSION@@' -Option Constant
-New-Variable -Name erts_version -Value '@@ERTS_VERSION@@' -Option Constant
+$package = 'erlang'
+$otp_version = '@@OTP_VERSION@@'
+$erts_version = '@@ERTS_VERSION@@'
 
 $params = @{
   PackageName = $package
@@ -27,11 +27,8 @@ $params = @{
 
 Install-ChocolateyPackage @params
 
-New-Variable -Name erlangProgramFilesPath -Option Constant `
-    -Value ((Get-ItemProperty -Path HKLM:\SOFTWARE\WOW6432Node\Ericsson\Erlang\$erts_version).'(default)')
-
-New-Variable -Name erlangErtsBinPath -Option Constant `
-    -Value (Join-Path -Path $erlangProgramFilesPath -ChildPath "erts-$erts_version" | Join-Path -ChildPath 'bin')
+$erlangProgramFilesPath = ((Get-ItemProperty -Path HKLM:\SOFTWARE\WOW6432Node\Ericsson\Erlang\$erts_version).'(default)')
+$erlangErtsBinPath = (Join-Path -Path $erlangProgramFilesPath -ChildPath "erts-$erts_version" | Join-Path -ChildPath 'bin')
 
 Install-BinFile -Name 'ct_run'   -Path (Join-Path -Path $erlangErtsBinPath -ChildPath 'ct_run.exe')
 Install-BinFile -Name 'erl'      -Path (Join-Path -Path $erlangErtsBinPath -ChildPath 'erl.exe')

--- a/tools/chocolateyUninstall.ps1.in
+++ b/tools/chocolateyUninstall.ps1.in
@@ -7,19 +7,17 @@ Author: Luke Bakken - luke@bakken.io
 Version: 1.0.0
 #>
 
-New-Variable -Name package -Value 'erlang' -Option Constant
-New-Variable -Name otp_version -Value '@@OTP_VERSION@@' -Option Constant
-New-Variable -Name erts_version -Value '@@ERTS_VERSION@@' -Option Constant
+$package = 'erlang'
+$otp_version = '@@OTP_VERSION@@'
+$erts_version = '@@ERTS_VERSION@@'
 
-New-Variable -Name erlangProgramFilesPath -Option Constant `
-    -Value ((Get-ItemProperty -Path HKLM:\SOFTWARE\WOW6432Node\Ericsson\Erlang\$erts_version).'(default)')
+$erlangProgramFilesPath = ((Get-ItemProperty -Path HKLM:\SOFTWARE\WOW6432Node\Ericsson\Erlang\$erts_version).'(default)')
 
 Start-Process -Wait -FilePath (Join-Path -Path $erlangProgramFilesPath -ChildPath 'uninstall.exe') -ArgumentList '/S'
 
 # ...and remove the shim files as well.
 
-New-Variable -Name erlangErtsBinPath -Option Constant `
-    -Value (Join-Path -Path $erlangProgramFilesPath -ChildPath "erts-$erts_version" | Join-Path -ChildPath 'bin')
+$erlangErtsBinPath = (Join-Path -Path $erlangProgramFilesPath -ChildPath "erts-$erts_version" | Join-Path -ChildPath 'bin')
 
 Uninstall-BinFile -Name 'ct_run'   -Path (Join-Path -Path $erlangErtsBinPath -ChildPath 'ct_run.exe')
 Uninstall-BinFile -Name 'erl'      -Path (Join-Path -Path $erlangErtsBinPath -ChildPath 'erl.exe')


### PR DESCRIPTION
see #1 

The chocolatey package internalizer 'choco download --internalize' does not understand variable declarations in the style of... `New-Variable -Name otp_version...` when parsing chocolateyInstall files.

Suggestion to use direct assignment (without New-Variable... call).

https://docs.chocolatey.org/en-us/features/package-internalizer

https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_variables?view=powershell-7.4